### PR TITLE
I18nを用いた国際化の実装・UIの美化・クエリパラメータを保持するように仕様を変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,8 @@ group :development do
   gem 'rubocop', '~> 1.45.1', require: false
   gem 'rubocop-fjord', require: false
   gem 'rubocop-rails', require: false
+
+  gem 'i18n_generators'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,9 @@ GEM
       activesupport (>= 5.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    i18n_generators (2.2.2)
+      activerecord (>= 3.0.0)
+      railties (>= 3.0.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -276,6 +279,7 @@ DEPENDENCIES
   carrierwave
   debug
   erb_lint
+  i18n_generators
   importmap-rails
   jbuilder
   puma

--- a/app/assets/stylesheets/scaffolds.css
+++ b/app/assets/stylesheets/scaffolds.css
@@ -1,0 +1,321 @@
+/****************
+Global
+****************/
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    font-family: sans-serif;
+    color: var(--global-c);
+}
+
+body {
+    padding: 24px;
+    margin: 0;
+}
+
+a:hover, a:active {
+    outline: 0;
+}
+
+a:link,
+a:visited {
+    color: var(--global-primary-c);
+}
+
+a:hover ,
+a:active {
+    color: var(--global-primary-c-hover);
+}
+
+body > br {
+    display: none;
+}
+
+body > *:first-child {
+    margin-top: 0;
+}
+
+input,
+textarea {
+    font-family: inherit;
+    outline: none;
+}
+
+input:focus-visible,
+textarea:focus-visible {
+    outline: solid 1px var(--global-primary-c);
+}
+
+img {
+    max-width: 100%;
+}
+
+p:empty {
+    display: none;
+}
+
+p:empty:first-child + * {
+    margin-top: 0;
+}
+
+input[type="submit"],
+input[type="file"],
+button[type="submit"] {
+    cursor: pointer;
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+    margin: 0 0 0 4px;
+    transform: translateY(0.125em);
+}
+
+input,
+button,
+a {
+    transition: all .2s ease-out;
+}
+
+/****************
+Common
+****************/
+
+:root {
+    /* border */
+    --global-bc: rgb(175, 175, 175);
+    --global-bc-muted: rgb(236, 236, 236);
+    --global-bw: 1px;
+    --global-br: 4px;
+    /* text */
+    --global-c: #444444;
+    --global-title-fz: 24px;
+    --global-headding-lh: 1.5;
+    --global-fz-md: 14px;
+    --global-fz-sm: 12px;
+    --global-label-fz: .9em;
+    --global-lh: 1.8;
+    /* primary */
+    --global-primary-c:#0088cc;
+    --global-primary-c-hover: #005580;
+    /* secondary */
+    --global-secondary-bgc: rgb(233, 233, 233);
+    --global-secondary-bgc-hover: rgb(212, 212, 212);
+    /* danger */
+    --global-danger-c: #dd2424;
+    --global-danger-bgc: #fff5f5;
+    --global-danger-bc: #fabfbf;
+    /* success */
+    --global-success-c: green;
+    /* index */
+    --global-block-gap: 12px;
+    /* single-column */
+    --single-column-w: 640px;
+}
+
+h1,
+h2 {
+    font-size: var(--global-title-fz);
+    line-height: var(--global-headding-lh);
+    margin: 1em 0;
+}
+
+h3 {
+    font-size: var(--global-fz-md);
+    line-height: var(--global-headding-lh);
+    margin: 1em 0;
+}
+
+.button_to button[type="submit"],
+.button_to input[type="submit"] {
+    background-color: var(--global-secondary-bgc);
+    border: solid var(--global-bw) var(--global-secondary-bgc-hover);
+    border-radius: var(--global-br);
+    height: 2em;
+    padding: 0 .75em;
+}
+
+.button_to button[type="submit"]:hover,
+.button_to input[type="submit"]:hover {
+    background-color: var(--global-secondary-bgc-hover);
+}
+
+/****************
+page-nav
+****************/
+
+.page-nav {
+    --nav-fz: var(--global-fz-md);
+    --nav-mt: 24px;
+    font-size: var(--nav-fz);
+    margin-top: var(--nav-mt);
+}
+
+.page-nav .button_to {
+    margin-top: var(--nav-mt);
+}
+
+/****************
+Index
+****************/
+
+.index-items {
+    display: grid;
+    gap: var(--global-block-gap);
+    grid-template-columns: repeat(auto-fill, 280px);
+    font-size: var(--global-fz-sm);
+    line-height: var(--global-lh);
+    margin-bottom: var(--nav-mt);
+}
+
+.index-item {
+    border: solid var(--global-bw) var(--global-bc);
+    padding: 16px;
+    border-radius: var(--global-br);
+    display: flex;
+    flex-direction: column;
+}
+
+.index-item div[id] {
+    flex: 1;
+}
+
+.index-item div[id] p {
+    margin: 0;
+    padding-top: 0.8em;
+    margin-bottom: 0.8em;
+    border-top: solid var(--global-bw) var(--global-bc-muted);
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 6;
+}
+
+.index-item div[id] p:first-child {
+    padding-top: 0;
+    border-top: none;
+}
+
+.index-item strong {
+    font-size: var(--global-label-fz);
+}
+
+.index-item img {
+    max-height: 160px;
+    display: block;
+    margin: 4px auto 0;
+    object-fit: contain;
+}
+
+.index-item > p {
+    margin-bottom: 0;
+    padding: 0.8em 0 0;
+    position: relative;
+    white-space: nowrap;
+    align-self: flex-end;
+    text-align: right;
+}
+
+/****************
+Show
+****************/
+
+.show-item {
+    max-width: var(--single-column-w);
+    display: block;
+    border: solid var(--global-bw) var(--global-bc);
+    padding: 24px;
+    border-radius: var(--global-br);
+    font-size: var(--global-fz-md);
+    line-height: var(--global-lh);
+}
+
+.show-item p {
+    margin: 0;
+    padding: 1em 0;
+    border-top: solid var(--global-bw) var(--global-bc-muted);
+}
+
+.show-item p:first-child {
+    padding-top: 0;
+    border-top: none;
+}
+
+.show-item p:last-child {
+    padding-bottom: 0;
+}
+
+.show-item p strong {
+    font-size: var(--global-label-fz);
+}
+
+.show-item img {
+    max-height: 400px;
+    display: block;
+    margin: 12px auto 0;
+    object-fit: contain;
+}
+
+/****************
+New and Edit
+****************/
+
+form:not(.button_to) {
+    --main-button-fz: 16px;
+    --main-button-w: 160px;
+    --main-button-h: 44px;
+    --main-button-mt: 24px;
+    max-width: var(--single-column-w);
+}
+
+form div:not(:first-of-type) {
+    margin-top: 1em;
+    line-height: var(--global-lh);
+}
+
+form div:last-of-type {
+    margin-top: var(--main-button-mt);
+}
+
+form label,
+form em,
+.field i {
+    font-size: 0.8em;
+    font-weight: bold;
+    margin-bottom: 0.25em;
+    font-style: normal;
+}
+
+form input[type="text"],
+form input[type="email"],
+form input[type="password"],
+form textarea {
+    width: 100%;
+    padding: 6px;
+    line-height: inherit;
+    border: solid var(--global-bw) var(--global-bc);
+    border-radius: var(--global-br);
+}
+
+form textarea {
+    height: 200px;
+}
+
+form input[type="submit"] {
+    font-size: var(--main-button-fz);
+    min-width: var(--main-button-w);
+    height: var(--main-button-h);
+    background-color: var(--global-primary-c);
+    border: solid 1px var(--global-primary-c-hover);
+    border-radius: var(--global-br);
+    color: #fff;
+    font-weight: bold;
+}
+
+form input[type="submit"]:hover {
+    background-color: var(--global-primary-c-hover);
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,13 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  around_action :switch_locale
+
+  private
+
+  def switch_locale(&action)
+    locale = params[:locale] || I18n.default_locale
+    I18n.with_locale(locale, &action)
+  end
 end
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,11 +3,21 @@
 class ApplicationController < ActionController::Base
   around_action :switch_locale
 
+  before_action :set_locale
+
+  def default_url_options
+    { locale: I18n.locale }.merge(super)
+  end
+
   private
 
   def switch_locale(&action)
     locale = params[:locale] || I18n.default_locale
     I18n.with_locale(locale, &action)
+  end
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
   end
 end
 

--- a/app/views/books/_book.html.erb
+++ b/app/views/books/_book.html.erb
@@ -1,21 +1,21 @@
 <div id="<%= dom_id book %>">
   <p>
-    <strong>Title:</strong>
+    <strong><%= Book.human_attribute_name(:title) %>:</strong>
     <%= book.title %>
   </p>
 
   <p>
-    <strong>Memo:</strong>
+    <strong><%= Book.human_attribute_name(:memo) %>:</strong>
     <%= book.memo %>
   </p>
 
   <p>
-    <strong>Author:</strong>
+    <strong><%= Book.human_attribute_name(:author) %>:</strong>
     <%= book.author %>
   </p>
 
   <p>
-    <strong>Picture:</strong>
+    <strong><%= Book.human_attribute_name(:picture) %>:</strong>
     <%= image_tag(book.picture_url) if book.picture.present? %>
   </p>
 

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -4,7 +4,7 @@
 
 <br>
 
-<div>
+<nav class="page-nav">
   <%= link_to t('views.common.show', name: Book.model_name.human.downcase), @book %> |
   <%= link_to t('views.common.back', name: Book.model_name.human.downcase), books_path %>
-</div>
+</nav>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -1,10 +1,10 @@
-<h1>Editing book</h1>
+<h1><%= t('views.common.title_edit', name: Book.model_name.human.downcase) %></h1>
 
 <%= render "form", book: @book %>
 
 <br>
 
 <div>
-  <%= link_to "Show this book", @book %> |
-  <%= link_to "Back to books", books_path %>
+  <%= link_to t('views.common.show', name: Book.model_name.human.downcase), @book %> |
+  <%= link_to t('views.common.back', name: Book.model_name.human.downcase), books_path %>
 </div>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -2,13 +2,17 @@
 
 <h1><%= t('views.common.title_index', name: Book.model_name.human) %></h1>
 
-<div id="books">
+<div id="books" class="index-items">
   <% @books.each do |book| %>
-    <%= render book %>
-    <p>
-      <%= link_to t('views.common.show', name: Book.model_name.human.downcase), book %>
-    </p>
+    <div class="index-item">
+      <%= render book %>
+      <p>
+        <%= link_to t('views.common.show', name: Book.model_name.human.downcase), book %>
+      </p>
+    </div>
   <% end %>
 </div>
 
-<%= link_to t('views.common.new', name: Book.model_name.human.downcase), new_book_path %>
+<nav class="page-nav">
+  <%= link_to t('views.common.new', name: Book.model_name.human.downcase), new_book_path %>
+</nav>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,14 +1,14 @@
 <p style="color: green"><%= notice %></p>
 
-<h1>Books</h1>
+<h1><%= t('views.common.title_index', name: Book.model_name.human) %></h1>
 
 <div id="books">
   <% @books.each do |book| %>
     <%= render book %>
     <p>
-      <%= link_to "Show this book", book %>
+      <%= link_to t('views.common.show', name: Book.model_name.human.downcase), book %>
     </p>
   <% end %>
 </div>
 
-<%= link_to "New book", new_book_path %>
+<%= link_to t('views.common.new', name: Book.model_name.human.downcase), new_book_path %>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,9 +1,9 @@
-<h1>New book</h1>
+<h1><%= t('views.common.title_new', name: Book.model_name.human.downcase) %></h1>
 
 <%= render "form", book: @book %>
 
 <br>
 
 <div>
-  <%= link_to "Back to books", books_path %>
+  <%= link_to t('views.common.back', name: Book.model_name.human.downcase), books_path %>
 </div>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -4,6 +4,6 @@
 
 <br>
 
-<div>
+<nav class="page-nav">
   <%= link_to t('views.common.back', name: Book.model_name.human.downcase), books_path %>
-</div>
+</nav>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,10 +1,12 @@
 <p style="color: green"><%= notice %></p>
 
-<%= render @book %>
+<div class="show-item">
+  <%= render @book %>
+</div>
 
-<div>
+<nav class="page-nav">
   <%= link_to t('views.common.edit', name: Book.model_name.human.downcase), edit_book_path(@book) %> |
   <%= link_to t('views.common.back', name: Book.model_name.human.downcase), books_path %>
 
   <%= button_to t('views.common.destroy', name: Book.model_name.human.downcase), @book, method: :delete %>
-</div>
+</nav>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -3,8 +3,8 @@
 <%= render @book %>
 
 <div>
-  <%= link_to "Edit this book", edit_book_path(@book) %> |
-  <%= link_to "Back to books", books_path %>
+  <%= link_to t('views.common.edit', name: Book.model_name.human.downcase), edit_book_path(@book) %> |
+  <%= link_to t('views.common.back', name: Book.model_name.human.downcase), books_path %>
 
-  <%= button_to "Destroy this book", @book, method: :delete %>
+  <%= button_to t('views.common.destroy', name: Book.model_name.human.downcase), @book, method: :delete %>
 </div>

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,2 @@
+I18n.available_locales = [:en, :ja]
+I18n.default_locale = :ja

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,217 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
+---
 en:
-  hello: "Hello world"
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'Validation failed: %{errors}'
+        restrict_dependent_destroy:
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
+  date:
+    abbr_day_names:
+    - Sun
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    abbr_month_names:
+    - 
+    - Jan
+    - Feb
+    - Mar
+    - Apr
+    - May
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Oct
+    - Nov
+    - Dec
+    day_names:
+    - Sunday
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+    - Saturday
+    formats:
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    - 
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: about %{count} hour
+        other: about %{count} hours
+      about_x_months:
+        one: about %{count} month
+        other: about %{count} months
+      about_x_years:
+        one: about %{count} year
+        other: about %{count} years
+      almost_x_years:
+        one: almost %{count} year
+        other: almost %{count} years
+      half_a_minute: half a minute
+      less_than_x_seconds:
+        one: less than %{count} second
+        other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
+      over_x_years:
+        one: over %{count} year
+        other: over %{count} years
+      x_seconds:
+        one: "%{count} second"
+        other: "%{count} seconds"
+      x_minutes:
+        one: "%{count} minute"
+        other: "%{count} minutes"
+      x_days:
+        one: "%{count} day"
+        other: "%{count} days"
+      x_months:
+        one: "%{count} month"
+        other: "%{count} months"
+      x_years:
+        one: "%{count} year"
+        other: "%{count} years"
+    prompts:
+      second: Second
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
+      year: Year
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: must be accepted
+      blank: can't be blank
+      confirmation: doesn't match %{attribute}
+      empty: can't be empty
+      equal_to: must be equal to %{count}
+      even: must be even
+      exclusion: is reserved
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      in: must be in %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      less_than: must be less than %{count}
+      less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: 'Validation failed: %{errors}'
+      not_a_number: is not a number
+      not_an_integer: must be an integer
+      odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
+      required: must exist
+      taken: has already been taken
+      too_long:
+        one: is too long (maximum is %{count} character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is %{count} character)
+        other: is too short (minimum is %{count} characters)
+      wrong_length:
+        one: is the wrong length (should be %{count} character)
+        other: is the wrong length (should be %{count} characters)
+    template:
+      body: 'There were problems with the following fields:'
+      header:
+        one: "%{count} error prohibited this %{model} from being saved"
+        other: "%{count} errors prohibited this %{model} from being saved"
+  helpers:
+    select:
+      prompt: Please select
+    submit:
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: pm

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,3 +215,13 @@ en:
       long: "%B %d, %Y %H:%M"
       short: "%d %b %H:%M"
     pm: pm
+  views:
+    common:
+      show: "View details of %{name}"
+      edit: "Edit %{name}"
+      destroy: "Are you sure you want to delete %{name}?"
+      new: "Register a new %{name}"
+      back: "Back to %{name} list"
+      title_index: "%{name} List"
+      title_new: "Register New %{name}"
+      title_edit: "Edit %{name}"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,183 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours: 約%{count}時間
+      about_x_months: 約%{count}ヶ月
+      about_x_years: 約%{count}年
+      almost_x_years: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds: "%{count}秒未満"
+      less_than_x_minutes: "%{count}分未満"
+      over_x_years: "%{count}年以上"
+      x_seconds: "%{count}秒"
+      x_minutes: "%{count}分"
+      x_days: "%{count}日"
+      x_months: "%{count}ヶ月"
+      x_years: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      in: は%{count}の範囲に含めてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -181,3 +181,13 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
+  views:
+    common:
+      show: "%{name}の詳細を見る"
+      edit: "%{name}を編集する"
+      destroy: "%{name}を削除しますか？"
+      new: "新規%{name}を登録"
+      back: "%{name}一覧に戻る"
+      title_index: "%{name}一覧"
+      title_new: "新規%{name}の登録"
+      title_edit: "%{name}の編集"

--- a/config/locales/translation_en.yml
+++ b/config/locales/translation_en.yml
@@ -1,0 +1,11 @@
+en:
+  activerecord:
+    models:
+      book: Book  #g
+
+    attributes:
+      book:
+        author: Author  #g
+        memo: Memo  #g
+        picture: Picture  #g
+        title: Title  #g

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -1,0 +1,11 @@
+ja:
+  activerecord:
+    models:
+      book: 本  #g
+
+    attributes:
+      book:
+        author: 著者  #g
+        memo: メモ  #g
+        picture: 写真  #g
+        title: タイトル  #g


### PR DESCRIPTION
- i18n_generatorsを用いて翻訳を自動生成、I18nの設定の追加
- Internationalizationの実装
- ?locale=ja 等のクエリパラメータをページ遷移時にも保持するように変更
- cssを定義してUIを見やすくした